### PR TITLE
Fix the footer copyright notice being LTR instead of RTL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,7 +134,7 @@ const WidgetifyLandingPage = () => {
 			<ContributorsSection />
 
 			<footer className="py-8 text-center text-white bg-gray-800">
-				<p>© {new Date().getFullYear()} ویجتیفای. تمامی حقوق محفوظ است.</p>
+				<p dir="rtl">© {new Date().getFullYear()} ویجتیفای. تمامی حقوق محفوظ است.</p>
 			</footer>
 		</div>
 	)


### PR DESCRIPTION
The footer copyright notixe is LTR causing the punctuation being in the wrong orientation. this PR solves that by adding a `dir="rtl"` to the `p` tag