### PR TITLE
Fix a typo on the web app's title

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 
 
   <title>
-    ویجتی‌فای - widgetify
+    ویجتی‌فای - Widgetify
   </title>
 </head>
 


### PR DESCRIPTION
The web app's title had a typo, the name (Widgetify) was not cased correctly and was written in all lowercase.